### PR TITLE
Fixed the Sorting Background Issue

### DIFF
--- a/src/components/ContributionTable/ContributionTable.tsx
+++ b/src/components/ContributionTable/ContributionTable.tsx
@@ -7,6 +7,7 @@ import {
   MRT_SortingState,
   useMantineReactTable,
 } from 'mantine-react-table'
+import 'mantine-react-table/styles.css'
 import React, { useEffect, useMemo, useState } from 'react'
 import dayjs from 'dayjs'
 import { Group, Pagination, ScrollArea, Select, Text, Tooltip } from '@mantine/core'


### PR DESCRIPTION
Closing #205 


The author suggested to import "mantine-react-table/style.css"

<img width="1743" alt="image" src="https://github.com/user-attachments/assets/d9a7d079-b8eb-46d0-bd30-93fe6d999403">


According to their beta-7 version styling now the toolbar will always be on the right side of the table. 
I initially tried custom styling for moving it to the left side, but no luck. They left the left side empty for custom buttons (export to excel etc).

