### PR TITLE
Added Error Handling

### DIFF
--- a/src/components/PortfolioCharts/PortfolioCharts.tsx
+++ b/src/components/PortfolioCharts/PortfolioCharts.tsx
@@ -1,8 +1,8 @@
 import { useViewportSize } from '@mantine/hooks'
-import { Paper, Tabs, MultiSelect, Box, rem, Select } from '@mantine/core'
+import { Paper, Tabs, MultiSelect, Box, rem, Select, Alert } from '@mantine/core'
 import { AttributeChart } from '../AttributeChart'
 import { CarbonIntensityChart } from '../CarbonIntensityChart'
-import { IconPrinter } from '@tabler/icons-react'
+import { IconPrinter, IconExclamationCircle } from '@tabler/icons-react'
 import { useState } from 'react'
 import domtoimage from 'dom-to-image'
 import { theme } from '@components'
@@ -101,6 +101,7 @@ export const PortfolioCharts = (props: PortfolioChartsProps) => {
   const { className, filters, mode } = props
   const [selectedCharts, setSelectedCharts] = useState<string[]>(DEFAULT_VISIBLE_CHARTS)
   const [selectedCarbonColumn, setSelectedCarbonColumn] = useState<string>(CARBON_INTENSITY_COLUMNS[0].value)
+  const [showWarning, setShowWarning] = useState(false)
   const { height } = useViewportSize()
 
   const chartId = mode === 'attribute' ? 'attributes' : 'intensity'
@@ -119,6 +120,15 @@ export const PortfolioCharts = (props: PortfolioChartsProps) => {
     }
   }
 
+  const handleChartsChange = (newSelection: string[]) => {
+    if (newSelection.length === 0) {
+      setShowWarning(true)
+      return
+    }
+    setShowWarning(false)
+    setSelectedCharts(newSelection)
+  }
+
   return (
     <Paper shadow='xs' p='md' mb='xl' className={className}>
       <Tabs keepMounted={false} onChange={handleTabChange}>
@@ -131,10 +141,15 @@ export const PortfolioCharts = (props: PortfolioChartsProps) => {
       {mode === 'attribute' ? (
         <>
           <Box mb='md'>
+            {showWarning && (
+              <Alert icon={<IconExclamationCircle size={16} />} color='yellow' mb='md' title='Chart Selection Required'>
+                At least one chart needs to be selected at all times
+              </Alert>
+            )}
             <MultiSelect
               data={CHART_COLUMNS}
               value={selectedCharts}
-              onChange={setSelectedCharts}
+              onChange={handleChartsChange}
               label='Select charts to display'
               placeholder='Choose charts'
               searchable


### PR DESCRIPTION
Closing #273 

For Carbon Intensity Chart:

This condition is already satisfied as one column will always be selected

<img width="1703" alt="image" src="https://github.com/user-attachments/assets/8a4b4d6f-f664-43c7-b2f8-d32a21d3332a" />

For Attribute Chart:

Now if a user tries to unselect all columns, warning will be shown. Its now a forbidden action. Atleast one column must be selected at all times

<img width="1714" alt="image" src="https://github.com/user-attachments/assets/dbe3393e-2ad0-4cda-b2ae-3bba8540f9d5" />

The warning only comes when i try to remove the last column (Country)